### PR TITLE
FWD-761: add 20900.flytrex.diagnostics.fpc.OpenLoopData

### DIFF
--- a/flytrex/diagnostics/fpc/20900.OpenLoopData.uavcan
+++ b/flytrex/diagnostics/fpc/20900.OpenLoopData.uavcan
@@ -4,5 +4,5 @@ float16 ia_rms_A                  # RMS A phase current
 float16 ib_rms_A                  # RMS B phase current
 float16 input_voltage_V           # Input voltage as measured
 float16 temperature_degC          # Unit temperature as measured
-bool[16] error_flags              # Same as in Flytrex's version of 
+bool[16] error_flags              # Same meaning as in Flytrex's version of esc.Status
 uint16 last_second_raw_commands   # How many esc.RawCommands were received in the last second?

--- a/flytrex/diagnostics/fpc/20900.OpenLoopData.uavcan
+++ b/flytrex/diagnostics/fpc/20900.OpenLoopData.uavcan
@@ -1,0 +1,9 @@
+# FPC Diagnostic Open Loop Data
+
+float16 ia_rms
+float16 ib_rms
+float16 input_voltage
+float16 temperature
+uint8 remaining_time
+bool[16] error_flags
+uint16 last_second_raw_commands

--- a/flytrex/diagnostics/fpc/20900.OpenLoopData.uavcan
+++ b/flytrex/diagnostics/fpc/20900.OpenLoopData.uavcan
@@ -4,5 +4,5 @@ float16 ia_rms_A                  # RMS A phase current
 float16 ib_rms_A                  # RMS B phase current
 float16 input_voltage_V           # Input voltage as measured
 float16 temperature_degC          # Unit temperature as measured
-bool[16] error_flags              # Same meaning as in Flytrex's version of esc.Status
+bool[16] error_flags              # Bit array representing specific error flags (see FPC documentation)
 uint16 last_second_raw_commands   # How many esc.RawCommands were received in the last second?

--- a/flytrex/diagnostics/fpc/20900.OpenLoopData.uavcan
+++ b/flytrex/diagnostics/fpc/20900.OpenLoopData.uavcan
@@ -1,9 +1,8 @@
-# FPC Diagnostic Open Loop Data
+# Propulsion Controller: Diagnostic Open Loop Data for automated end-of-line testing
 
-float16 ia_rms
-float16 ib_rms
-float16 input_voltage
-float16 temperature
-uint8 remaining_time
-bool[16] error_flags
-uint16 last_second_raw_commands
+float16 ia_rms_A                  # RMS A phase current
+float16 ib_rms_A                  # RMS B phase current
+float16 input_voltage_V           # Input voltage as measured
+float16 temperature_degC          # Unit temperature as measured
+bool[16] error_flags              # Same as in Flytrex's version of 
+uint16 last_second_raw_commands   # How many esc.RawCommands were received in the last second?


### PR DESCRIPTION
[This is only for factory line testing purposes to comminicate with test host Python sofware as detailed in the TA requirements.](https://flytrex.atlassian.net/wiki/spaces/EL/pages/3337322499/FPC+EOL+TA#FPC-Firmware)